### PR TITLE
Hide fields from forms

### DIFF
--- a/basis/models.py
+++ b/basis/models.py
@@ -7,13 +7,13 @@ from .managers import BasisModelManager
 
 
 class BasisModel(models.Model):
-    deleted = models.BooleanField(default=False)
+    deleted = models.BooleanField(default=False, editable=False)
 
-    created_at = models.DateTimeField(default=datetime.now, auto_now_add=True)
-    created_by = models.ForeignKey(get_user_model(), null=True, default=None, related_name="%(class)s_created")
+    created_at = models.DateTimeField(default=datetime.now, editable=False, auto_now_add=True)
+    created_by = models.ForeignKey(get_user_model(), null=True, default=None, editable=False, related_name="%(class)s_created")
 
-    updated_at = models.DateTimeField(default=datetime.now, auto_now=True)
-    updated_by = models.ForeignKey(get_user_model(), null=True, default=None, related_name="%(class)s_updated")
+    updated_at = models.DateTimeField(default=datetime.now, editable=False, auto_now=True)
+    updated_by = models.ForeignKey(get_user_model(), null=True, default=None, editable=False, related_name="%(class)s_updated")
 
     objects = BasisModelManager()
     all_objects = models.Manager()


### PR DESCRIPTION
This pull-request sets editable to False on `deleted`, `created_at`, `created_by`, `updated_at` and `updated_by`. Those fields will be hidden from all ModelForms for the models that inherit from BasisModel
