### PR TITLE
Add support for force deleting persisting model

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ print Person.all_objects.all().count() # 1 - includes deleted users
 # Restore deleted person
 person = Person.all_objects.get(id=person.id)
 person.restore()
+
+# If you really want to delete the object
+person = Person.objects.create(name="Fredrik"))
+person.delete(force=True)
 ```
 
 

--- a/basis/models.py
+++ b/basis/models.py
@@ -35,9 +35,12 @@ class PersistentModel(models.Model):
     class Meta:
         abstract = True
 
-    def delete(self, *args, **kwargs):
-        self.deleted = True
-        self.save(*args, **kwargs)
+    def delete(self, using=None, force=False):
+        if force:
+            super(PersistentModel, self).delete(using)
+        else:
+            self.deleted = True
+            self.save()
 
     def restore(self, *args, **kwargs):
         self.deleted = False

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,4 +1,5 @@
 # -*- coding: utf8 -*-
+import sys
 from datetime import datetime
 
 from django.utils import unittest, timezone
@@ -6,6 +7,13 @@ from django.test.utils import override_settings
 
 from basis.compat import get_user_model
 from .models import Person
+
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    from unittest import mock
+else:
+    import mock
 
 
 class TestTimeStampModel(unittest.TestCase):
@@ -70,6 +78,12 @@ class TestPersistentModel(unittest.TestCase):
         person = Person.objects.create(current_user=self.user1)
         person.delete(force=True)
         self.assertEqual(Person.all_objects.count(), 0)
+
+    @mock.patch('django.db.models.base.Model.delete')
+    def test_delete_with_using(self, mock_delete):
+        person = Person.objects.create(current_user=self.user1)
+        person.delete(force=True, using='other_db')
+        mock_delete.assert_called_with('other_db')
 
 
 class TestBasisModel(unittest.TestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -66,6 +66,11 @@ class TestPersistentModel(unittest.TestCase):
         self.assertEqual(Person.objects.all().count(), 0)
         self.assertEqual(Person.all_objects.all().count(), 1)
 
+    def test_force_delete(self):
+        person = Person.objects.create(current_user=self.user1)
+        person.delete(force=True)
+        self.assertEqual(Person.all_objects.count(), 0)
+
 
 class TestBasisModel(unittest.TestCase):
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ commands =
     coverage run -p --source=basis runtests.py
 deps =
     coverage
+    mock
     django14: Django>=1.4,<1.5
     django15: Django>=1.5,<1.6
     django16: Django>=1.6,<1.7


### PR DESCRIPTION
By calling `instance.delete(force=True)` the default django
Model.delete() will be called.