### PR TITLE
Remove false documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,6 @@ print Person.all_objects.all().count() # 1 - includes deleted users
 # Restore deleted person
 person = Person.all_objects.get(id=person.id)
 person.restore()
-
-# If you really want to delete the object
-person = Person.all_objects.get(id=person.id)
-person.delete()
 ```
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -62,6 +62,9 @@ class TestPersistentModel(unittest.TestCase):
 
         person.restore()
         self.assertEqual(Person.objects.all().count(), 1)
+        Person.all_objects.all()[0].delete()
+        self.assertEqual(Person.objects.all().count(), 0)
+        self.assertEqual(Person.all_objects.all().count(), 1)
 
 
 class TestBasisModel(unittest.TestCase):


### PR DESCRIPTION
As shown in the added test code fetching the object from all_objects
will not make it possible to run delete and actually delete the object,
since it will still be a PersistenModel instance which has overrided the
`delete()` method.