### PR TITLE
Fix flake8 E402 error

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -4,9 +4,9 @@ import sys
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
 
-from django.test.utils import get_runner
-from django.conf import settings
-import django
+from django.test.utils import get_runner  # noqa
+from django.conf import settings  # noqa
+import django  # noqa
 
 if django.VERSION >= (1, 7):
     django.setup()


### PR DESCRIPTION
Added ignore statement to the imports since the DJANGO_SETTINGS_MODULE
environment variable must be set before importing things from django or
the app loading will fail.