### PR TITLE
Fixed created_by and updated_by not being saved correctly.

### DIFF
--- a/basis/managers.py
+++ b/basis/managers.py
@@ -5,9 +5,9 @@ from .compat import DJANGO16
 class _PersistentModelManager(models.Manager):
     def create(self, *args, **kwargs):
         user = kwargs.pop('current_user', None)
+        kwargs['created_by'] = user
+        kwargs['updated_by'] = user
         instance = super(_PersistentModelManager, self).create(*args, **kwargs)
-        instance.created_by = user
-        instance.updated_by = user
         return instance
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -107,34 +107,54 @@ class TestBasisModel(unittest.TestCase):
         self.assertEqual(person.updated_by, None)
 
     def test_save_person_with_user(self):
-        person = Person()
+        person = Person(name='john doe')
         person.save(current_user=self.user1)
 
         self.assertEqual(person.created_by, self.user1)
         self.assertEqual(person.updated_by, self.user1)
 
+        p = Person.objects.get(name='john doe')
+        self.assertEqual(p.created_by, self.user1)
+        self.assertEqual(p.updated_by, self.user1)
+
     def test_create_person_without_user(self):
-        person = Person.objects.create()
+        person = Person.objects.create(name='john doe')
 
         self.assertEqual(person.created_by, None)
         self.assertEqual(person.updated_by, None)
 
+        p = Person.objects.get(name='john doe')
+        self.assertEqual(p.created_by, None)
+        self.assertEqual(p.updated_by, None)
+
     def test_create_person_with_user(self):
-        person = Person.objects.create(current_user=self.user1)
+        person = Person.objects.create(name='john doe', current_user=self.user1)
 
         self.assertEqual(person.created_by, self.user1)
         self.assertEqual(person.updated_by, self.user1)
+
+        p = Person.objects.get(name='john doe')
+        self.assertEqual(p.created_by, self.user1)
+        self.assertEqual(p.updated_by, self.user1)
 
     def test_update_person_with_user(self):
-        person = Person.objects.create(current_user=self.user1)
+        person = Person.objects.create(name='john doe', current_user=self.user1)
 
         self.assertEqual(person.created_by, self.user1)
         self.assertEqual(person.updated_by, self.user1)
+
+        p = Person.objects.get(name='john doe')
+        self.assertEqual(p.created_by, self.user1)
+        self.assertEqual(p.updated_by, self.user1)
 
         person.save(current_user=self.user2)
 
         self.assertEqual(person.created_by, self.user1)
         self.assertEqual(person.updated_by, self.user2)
+
+        p = Person.objects.get(name='john doe')
+        self.assertEqual(p.created_by, self.user1)
+        self.assertEqual(p.updated_by, self.user2)
 
 
 class TestBasisSerializer(APITestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -113,9 +113,9 @@ class TestBasisModel(unittest.TestCase):
         self.assertEqual(person.created_by, self.user1)
         self.assertEqual(person.updated_by, self.user1)
 
-        p = Person.objects.get(name='john doe')
-        self.assertEqual(p.created_by, self.user1)
-        self.assertEqual(p.updated_by, self.user1)
+        person_from_db = Person.objects.get(name='john doe')
+        self.assertEqual(person_from_db.created_by, self.user1)
+        self.assertEqual(person_from_db.updated_by, self.user1)
 
     def test_create_person_without_user(self):
         person = Person.objects.create(name='john doe')
@@ -123,9 +123,9 @@ class TestBasisModel(unittest.TestCase):
         self.assertEqual(person.created_by, None)
         self.assertEqual(person.updated_by, None)
 
-        p = Person.objects.get(name='john doe')
-        self.assertEqual(p.created_by, None)
-        self.assertEqual(p.updated_by, None)
+        person_from_db = Person.objects.get(name='john doe')
+        self.assertEqual(person_from_db.created_by, None)
+        self.assertEqual(person_from_db.updated_by, None)
 
     def test_create_person_with_user(self):
         person = Person.objects.create(name='john doe', current_user=self.user1)
@@ -133,9 +133,9 @@ class TestBasisModel(unittest.TestCase):
         self.assertEqual(person.created_by, self.user1)
         self.assertEqual(person.updated_by, self.user1)
 
-        p = Person.objects.get(name='john doe')
-        self.assertEqual(p.created_by, self.user1)
-        self.assertEqual(p.updated_by, self.user1)
+        person_from_db = Person.objects.get(name='john doe')
+        self.assertEqual(person_from_db.created_by, self.user1)
+        self.assertEqual(person_from_db.updated_by, self.user1)
 
     def test_update_person_with_user(self):
         person = Person.objects.create(name='john doe', current_user=self.user1)
@@ -143,18 +143,18 @@ class TestBasisModel(unittest.TestCase):
         self.assertEqual(person.created_by, self.user1)
         self.assertEqual(person.updated_by, self.user1)
 
-        p = Person.objects.get(name='john doe')
-        self.assertEqual(p.created_by, self.user1)
-        self.assertEqual(p.updated_by, self.user1)
+        person_from_db = Person.objects.get(name='john doe')
+        self.assertEqual(person_from_db.created_by, self.user1)
+        self.assertEqual(person_from_db.updated_by, self.user1)
 
         person.save(current_user=self.user2)
 
         self.assertEqual(person.created_by, self.user1)
         self.assertEqual(person.updated_by, self.user2)
 
-        p = Person.objects.get(name='john doe')
-        self.assertEqual(p.created_by, self.user1)
-        self.assertEqual(p.updated_by, self.user2)
+        person_from_db = Person.objects.get(name='john doe')
+        self.assertEqual(person_from_db.created_by, self.user1)
+        self.assertEqual(person_from_db.updated_by, self.user2)
 
 
 class TestBasisSerializer(APITestCase):


### PR DESCRIPTION
As `instance.created_by` and `instance.updated_by` in `managers.py` was set
*after* the `.create()` call, the fields were never actually saved in the
database. They were, however, returned.

The previous tests succeded, because they only checked the data they got
back, and not what was in the database.