### PR TITLE
Fix PersistentModel's manager

### DIFF
--- a/basis/managers.py
+++ b/basis/managers.py
@@ -2,20 +2,20 @@ from django.db import models
 from .compat import DJANGO16
 
 
-class _PersistentModelManager(models.Manager):
+if DJANGO16:
+    class PersistentModelManager(models.Manager):
+        def get_queryset(self):
+            return super(PersistentModelManager, self).get_queryset().filter(deleted=False)
+else:
+    class PersistentModelManager(models.Manager):
+        def get_query_set(self):
+            return super(PersistentModelManager, self).get_query_set().filter(deleted=False)
+
+
+class BasisModelManager(PersistentModelManager):
     def create(self, *args, **kwargs):
         user = kwargs.pop('current_user', None)
         kwargs['created_by'] = user
         kwargs['updated_by'] = user
-        instance = super(_PersistentModelManager, self).create(*args, **kwargs)
+        instance = super(BasisModelManager, self).create(*args, **kwargs)
         return instance
-
-
-if DJANGO16:
-    class PersistentModelManager(_PersistentModelManager):
-        def get_queryset(self):
-            return super(PersistentModelManager, self).get_queryset().filter(deleted=False)
-else:
-    class PersistentModelManager(_PersistentModelManager):
-        def get_query_set(self):
-            return super(PersistentModelManager, self).get_query_set().filter(deleted=False)

--- a/basis/models.py
+++ b/basis/models.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.utils import timezone
 
 from .compat import AUTH_USER_MODEL
-from .managers import PersistentModelManager
+from .managers import PersistentModelManager, BasisModelManager
 
 
 def _now():
@@ -52,6 +52,8 @@ class BasisModel(TimeStampModel, PersistentModel):
                                    related_name="%(class)s_created")
     updated_by = models.ForeignKey(AUTH_USER_MODEL, null=True, default=None, editable=False,
                                    related_name="%(class)s_updated")
+
+    objects = BasisModelManager()
 
     class Meta:
         abstract = True

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,6 +1,14 @@
 from django.db import models
-from basis.models import BasisModel
+from basis.models import BasisModel, PersistentModel, TimeStampModel
 
 
-class Person(BasisModel):
+class BasisPerson(BasisModel):
+    name = models.CharField(max_length=100)
+
+
+class TimeStampPerson(TimeStampModel):
+    name = models.CharField(max_length=100)
+
+
+class PersistentPerson(PersistentModel):
     name = models.CharField(max_length=100)

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -1,7 +1,7 @@
 from basis.serializers import BasisSerializer
-from .models import Person
+from .models import BasisPerson
 
 
 class PersonSerializer(BasisSerializer):
     class Meta:
-        model = Person
+        model = BasisPerson

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,7 +8,7 @@ from django.utils import unittest, timezone
 from django.test.utils import override_settings
 
 from basis.compat import get_user_model
-from .models import Person
+from .models import TimeStampPerson, PersistentPerson, BasisPerson
 from .views import BasisModelViewSet
 
 PY3 = sys.version_info[0] == 3
@@ -27,10 +27,10 @@ class TestTimeStampModel(unittest.TestCase):
 
     def tearDown(self):
         get_user_model().objects.all().delete()
-        Person.all_objects.all().delete()
+        TimeStampPerson.objects.all().delete()
 
     def test_datetimes(self):
-        person = Person.objects.create(current_user=self.user1)
+        person = TimeStampPerson.objects.create()
 
         self.assertAlmostEqual(int(person.created_at.strftime('%Y%m%d%H%M%S')),
                                int(datetime.now().strftime('%Y%m%d%H%M%S')))
@@ -41,7 +41,7 @@ class TestTimeStampModel(unittest.TestCase):
 
     @override_settings(USE_TZ=True)
     def test_datetimes_with_timezone(self):
-        person = Person.objects.create(current_user=self.user1)
+        person = TimeStampPerson.objects.create()
         self.assertEqual(person.created_at.tzinfo, timezone.utc)
         self.assertEqual(person.updated_at.tzinfo, timezone.utc)
 
@@ -61,30 +61,30 @@ class TestPersistentModel(unittest.TestCase):
 
     def tearDown(self):
         get_user_model().objects.all().delete()
-        Person.all_objects.all().delete()
+        PersistentPerson.all_objects.all().delete()
 
     def test_delete_person(self):
-        person = Person.objects.create(current_user=self.user1)
+        person = PersistentPerson.objects.create()
 
-        self.assertEqual(Person.objects.all().count(), 1)
+        self.assertEqual(PersistentPerson.objects.all().count(), 1)
         person.delete()
-        self.assertEqual(Person.objects.all().count(), 0)
-        self.assertEqual(Person.all_objects.all().count(), 1)
+        self.assertEqual(PersistentPerson.objects.all().count(), 0)
+        self.assertEqual(PersistentPerson.all_objects.all().count(), 1)
 
         person.restore()
-        self.assertEqual(Person.objects.all().count(), 1)
-        Person.all_objects.all()[0].delete()
-        self.assertEqual(Person.objects.all().count(), 0)
-        self.assertEqual(Person.all_objects.all().count(), 1)
+        self.assertEqual(PersistentPerson.objects.all().count(), 1)
+        PersistentPerson.all_objects.all()[0].delete()
+        self.assertEqual(PersistentPerson.objects.all().count(), 0)
+        self.assertEqual(PersistentPerson.all_objects.all().count(), 1)
 
     def test_force_delete(self):
-        person = Person.objects.create(current_user=self.user1)
+        person = PersistentPerson.objects.create()
         person.delete(force=True)
-        self.assertEqual(Person.all_objects.count(), 0)
+        self.assertEqual(PersistentPerson.all_objects.count(), 0)
 
     @mock.patch('django.db.models.base.Model.delete')
     def test_delete_with_using(self, mock_delete):
-        person = Person.objects.create(current_user=self.user1)
+        person = PersistentPerson.objects.create()
         person.delete(force=True, using='other_db')
         mock_delete.assert_called_with('other_db')
 
@@ -97,53 +97,53 @@ class TestBasisModel(unittest.TestCase):
 
     def tearDown(self):
         get_user_model().objects.all().delete()
-        Person.all_objects.all().delete()
+        BasisPerson.all_objects.all().delete()
 
     def test_save_person_without_user(self):
-        person = Person()
+        person = BasisPerson()
         person.save()
 
         self.assertEqual(person.created_by, None)
         self.assertEqual(person.updated_by, None)
 
     def test_save_person_with_user(self):
-        person = Person(name='john doe')
+        person = BasisPerson(name='john doe')
         person.save(current_user=self.user1)
 
         self.assertEqual(person.created_by, self.user1)
         self.assertEqual(person.updated_by, self.user1)
 
-        person_from_db = Person.objects.get(name='john doe')
+        person_from_db = BasisPerson.objects.get(name='john doe')
         self.assertEqual(person_from_db.created_by, self.user1)
         self.assertEqual(person_from_db.updated_by, self.user1)
 
     def test_create_person_without_user(self):
-        person = Person.objects.create(name='john doe')
+        person = BasisPerson.objects.create(name='john doe')
 
         self.assertEqual(person.created_by, None)
         self.assertEqual(person.updated_by, None)
 
-        person_from_db = Person.objects.get(name='john doe')
+        person_from_db = BasisPerson.objects.get(name='john doe')
         self.assertEqual(person_from_db.created_by, None)
         self.assertEqual(person_from_db.updated_by, None)
 
     def test_create_person_with_user(self):
-        person = Person.objects.create(name='john doe', current_user=self.user1)
+        person = BasisPerson.objects.create(name='john doe', current_user=self.user1)
 
         self.assertEqual(person.created_by, self.user1)
         self.assertEqual(person.updated_by, self.user1)
 
-        person_from_db = Person.objects.get(name='john doe')
+        person_from_db = BasisPerson.objects.get(name='john doe')
         self.assertEqual(person_from_db.created_by, self.user1)
         self.assertEqual(person_from_db.updated_by, self.user1)
 
     def test_update_person_with_user(self):
-        person = Person.objects.create(name='john doe', current_user=self.user1)
+        person = BasisPerson.objects.create(name='john doe', current_user=self.user1)
 
         self.assertEqual(person.created_by, self.user1)
         self.assertEqual(person.updated_by, self.user1)
 
-        person_from_db = Person.objects.get(name='john doe')
+        person_from_db = BasisPerson.objects.get(name='john doe')
         self.assertEqual(person_from_db.created_by, self.user1)
         self.assertEqual(person_from_db.updated_by, self.user1)
 
@@ -152,7 +152,7 @@ class TestBasisModel(unittest.TestCase):
         self.assertEqual(person.created_by, self.user1)
         self.assertEqual(person.updated_by, self.user2)
 
-        person_from_db = Person.objects.get(name='john doe')
+        person_from_db = BasisPerson.objects.get(name='john doe')
         self.assertEqual(person_from_db.created_by, self.user1)
         self.assertEqual(person_from_db.updated_by, self.user2)
 
@@ -178,7 +178,7 @@ class TestBasisSerializer(APITestCase):
         self.assertEqual(response.data['updated_by'], self.user1.pk)
 
     def test_updated_by(self):
-        user = Person(name="username 123")
+        user = BasisPerson(name="username 123")
         user.save(current_user=self.user1)
         id = user.pk
 

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,8 +1,8 @@
 from rest_framework import viewsets
-from .models import Person
 from .serializers import PersonSerializer
+from .models import BasisPerson
 
 
 class BasisModelViewSet(viewsets.ModelViewSet):
-    queryset = Person.objects.all()
+    queryset = BasisPerson.objects.all()
     serializer_class = PersonSerializer


### PR DESCRIPTION
The PersistentModel manager shouldn't rely on the `created_by` and `updated_by` fields, that way it can't be used just for the `deleted`-functionality. This fix makes PersistentModel work on its own. Also updates the tests.